### PR TITLE
Оптимизирован compose-файл

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,26 +7,17 @@ services:
     env_file:
       - env_file
     restart: always
-    networks:
-      - db_nw
   tgbot:
     logging:
       options:
         max-size: "10M"
         max-file: "10"
     build: .
-    volumes:
-      - .:/src
     env_file:
       - env_file
     command: bash -c "python manage.py makemigrations data && python manage.py migrate data && python telegram.py"
     restart: always
-    networks:
-      - db_nw
     depends_on:
       - db
-networks:
-  db_nw:
-    driver: bridge
 volumes:
   dbdata:


### PR DESCRIPTION
В compose-файле можно не указывать сеть эксплицитно, если нужна одна бридж-сеть на все контейнеры, потому что такая и так создаётся по умолчанию.

Также не нужно монтировать папку с исходниками в /src, потому что они и так копируются в образ на этапе его сборки. Подозреваю, что это делалось для упрощения тестирования при разработке, чтобы быстрее вносить изменения, но образ очень простой и в любом случае должен пересобираться быстро.