### PR TITLE
Добавил чтение конфигурации из строки DATABASE_URL и инструкцию по деплою в Dokku

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -23,3 +23,5 @@ setenv.py
 # Docker
 docker-compose*.yml
 Dockerfile
+
+.venv

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ env_file
 openssl_config
 venv/
 commands/
+.venv

--- a/README.md
+++ b/README.md
@@ -46,6 +46,28 @@ ID можно узнать командой `/id` в боте или через 
 
 Не забудьте отключить бота из образа командой `docker-compose down`
 
+# Установка в Dokku
+
+На сервере:
+
+```bash
+dokku apps:create tgvkbot
+dokku postgres:create tgvkbot_db
+dokku postgres:link tgvkbot_db tgvkbot
+
+dokku config:set tgvkbot BOT_TOKEN=<tg_token> [VK_APP_ID=<vk_app_id> ALLOWED_USER_IDS=<tg_user_ids,...> MAX_FILE_SIZE=<num> ...]
+```
+
+На локальном компьютере/где угодно:
+
+```bash
+git clone https://github.com/dm1sh/tgvkbot
+cd tgvkbot
+git remote add dokku dokku@<dokku_host_url>:tgvkbot
+git push dokku
+```
+
+
 # Сервисы музыки (Устаревшие)
 Ниже прокси для музыки, которые использовали ранее. Сейчас они нерелевантны, но код открыт и в боте есть поддержка кастомных бэкендов музыки.
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ ID можно узнать командой `/id` в боте или через 
 
 # Установка в Dokku
 
+Подробнее о деплое через Dokku можно прочитать [здесь](https://dokku.com/docs/deployment/application-deployment/).
+
 На сервере:
 
 ```bash
@@ -58,11 +60,9 @@ dokku postgres:link tgvkbot_db tgvkbot
 dokku config:set tgvkbot BOT_TOKEN=<tg_token> [VK_APP_ID=<vk_app_id> ALLOWED_USER_IDS=<tg_user_ids,...> MAX_FILE_SIZE=<num> ...]
 ```
 
-На локальном компьютере/где угодно:
+На локальном компьютере/где угодно в папке с репозиторием:
 
 ```bash
-git clone https://github.com/dm1sh/tgvkbot
-cd tgvkbot
 git remote add dokku dokku@<dokku_host_url>:tgvkbot
 git push dokku
 ```

--- a/config.py
+++ b/config.py
@@ -1,5 +1,7 @@
 import os
 
+from django.core.management.utils import get_random_secret_key
+
 ALLOWED_USER_IDS = os.environ.get('ALLOWED_USER_IDS', '')
 
 DATABASE_USER = os.environ.get('POSTGRES_USER', 'postgres')
@@ -7,6 +9,8 @@ DATABASE_PASSWORD = os.environ.get('POSTGRES_PASSWORD', 'postgres')
 DATABASE_HOST = os.environ.get('DATABASE_HOST', 'db')
 DATABASE_PORT = os.environ.get('DATABASE_PORT', '5432')
 DATABASE_NAME = os.environ.get('POSTGRES_DB', 'tgvkbot')
+
+DATABASE_URL = os.environ.get('DATABASE_URL', '')
 
 VK_APP_ID = os.environ.get('VK_APP_ID', '2685278')  # Kate mobile
 
@@ -30,9 +34,7 @@ MAX_FILE_SIZE = os.environ.get('MAX_FILE_SIZE', 52428800)
 API_VERSION = os.environ.get('API_VERSION', '5.124')
 AUDIO_API_VERSION = os.environ.get('API_VERSION', '5.78')
 
-# https://www.miniwebtool.com/django-secret-key-generator/
-# Возможно достаточно заглушки в стиле 'tgvkbot-super-secret-key(nope)'
-SECRET_KEY = os.environ.get('SECRET_KEY', '!jh4wm=%s%l&jv7-lru6hg)mq2pk&rd@i*s0*c!v!zv01cf9iw')
+SECRET_KEY = os.environ.get('SECRET_KEY', get_random_secret_key())
 
 SENTRY_URL = os.environ.get('SENTRY_URL', None)
 

--- a/config.py
+++ b/config.py
@@ -1,7 +1,5 @@
 import os
 
-from django.core.management.utils import get_random_secret_key
-
 ALLOWED_USER_IDS = os.environ.get('ALLOWED_USER_IDS', '')
 
 DATABASE_USER = os.environ.get('POSTGRES_USER', 'postgres')
@@ -34,7 +32,7 @@ MAX_FILE_SIZE = os.environ.get('MAX_FILE_SIZE', 52428800)
 API_VERSION = os.environ.get('API_VERSION', '5.124')
 AUDIO_API_VERSION = os.environ.get('API_VERSION', '5.78')
 
-SECRET_KEY = os.environ.get('SECRET_KEY', get_random_secret_key())
+SECRET_KEY = os.environ.get('SECRET_KEY', '!jh4wm=%s%l&jv7-lru6hg)mq2pk&rd@i*s0*c!v!zv01cf9iw')
 
 SENTRY_URL = os.environ.get('SENTRY_URL', None)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ ujson==1.35
 urllib3==1.25.3
 wget==3.2
 yarl==1.1.1
+dj-database-url==0.5.0

--- a/settings.py
+++ b/settings.py
@@ -1,13 +1,12 @@
 from config import *
 
-import dj_database_url
-
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 DATABASES = {}
 
 if DATABASE_URL:
+    import dj_database_url
     # Reads string from DATABASE_URL env by default
     DATABASES['default'] = dj_database_url.config()
 else:

--- a/settings.py
+++ b/settings.py
@@ -4,11 +4,13 @@ import dj_database_url
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
-DATABASES = {
-    'default': dj_database_url.config(default=DATABASE_URL)
-}
 
-if not DATABASE_URL:
+DATABASES = {}
+
+if DATABASE_URL:
+    # Reads string from DATABASE_URL env by default
+    DATABASES['default'] = dj_database_url.config()
+else:
     DATABASES['default'] = {
         'ENGINE': 'django.db.backends.postgresql',
         'NAME': DATABASE_NAME,

--- a/settings.py
+++ b/settings.py
@@ -9,7 +9,7 @@ DATABASES = {
 }
 
 if not DATABASE_URL:
-    DATABASE['default'] = {
+    DATABASES['default'] = {
         'ENGINE': 'django.db.backends.postgresql',
         'NAME': DATABASE_NAME,
         'USER': DATABASE_USER,

--- a/settings.py
+++ b/settings.py
@@ -1,9 +1,15 @@
 from config import *
 
+import dj_database_url
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 DATABASES = {
-    'default': {
+    'default': dj_database_url.config(default=DATABASE_URL)
+}
+
+if not DATABASE_URL:
+    DATABASE['default'] = {
         'ENGINE': 'django.db.backends.postgresql',
         'NAME': DATABASE_NAME,
         'USER': DATABASE_USER,
@@ -11,7 +17,7 @@ DATABASES = {
         'HOST': DATABASE_HOST,
         'PORT': DATABASE_PORT
     }
-}
+
 INSTALLED_APPS = (
     'data',
 )


### PR DESCRIPTION
Мб, кому-то ещё будет удобно деплоить с подключением внешней базы данных по url, как в случае с [Dokku](https://dokku.com). Он автоматически пробрасывает в контейнер переменную `DATABASE_URL`. [dj_database_url](https://github.com/jacobian/dj-database-url) поддерживает не только postgres, поэтому можно деплоить с любыми базами данных, поддерживаемыми им и Django

p.s. для secret'а использовал встроенный django'вский генератор, думаю, лишним не будет